### PR TITLE
Update pull_request_template.md

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,32 +1,21 @@
-### 📃 Summary
-<!-- Enter a short description about what this PR contains. -->
-
-### 🔍 Changeset
-<!-- List out the code changes introduced by this PR. Data Migrations, Endpoints, etc -->
-
-### 🏷 JIRA Task
+### 📜 JIRA Task
 <!-- Provide a link to the associated JIRA task. -->
 
-### ↩️ Depends On
-<!-- Provide a link to any other PR dependencies. -->
+### 🌺 Summary
+<!-- Give a high level summary of your changes -->
 
-### 📸 Screenshots (before/after)
-<!-- If this PR alters any UI, provider before/after screenshots. -->
+### 🧪 Test Steps  
+<!-- Outline steps the reviewer can take to test these changes -->
 
-### 🧪 QA
-<!-- List out the steps to test the feature. -->
-
-### ✨ Style Guide
-[API Style Guide on Confluence](https://wheelhealth.atlassian.net/wiki/spaces/TH/pages/2497871875/Care+API+Code+Style+Guide)
-
-[We're also using eslint/prettier to manage coding styles](https://github.com/heydoctor/eslint-config)
+### 📸 Screenshots / Video
+<!-- Follow the steps outlined above to manually verify your changes -->
 
 ### 📈 Risk Analysis
-<!-- Provide a risk description -->
+<!-- Provide a risk description for compliance -->
 
 - [ ] Does this affect patients?
 - [ ] Does this affect clinical?
-- [ ] Does this mutate data?
+- [ ] Does this mutate production data?
 - [ ] Does it touch PHI?
 - [ ] Does it touch payments?
 


### PR DESCRIPTION
This pr simplifies our base pr template based on the recent discussion from our engineering meeting. We simplify the template to focus on manual testing, fewer sections as having too many section causes too much overhead and its easy to ignore parts of the template, our goal is to have fewer, more meaningful sections.  